### PR TITLE
Doc: Reuse settings content via tagged regions

### DIFF
--- a/docs/include/attributes-ls.asciidoc
+++ b/docs/include/attributes-ls.asciidoc
@@ -19,6 +19,14 @@ Logstash settings
 :plyml: Available in`pipelines.yml`.
 :bothyml: Available in `logstash.yml` and `pipelines.yml`.
 
+// # tag::lsyml[]
+Available in `logstash.yml`.
+// # end::lsyml[]
+
+// # tag::bothyml[]
+Available in `logstash.yml` and `pipelines.yml`.
+// # end::bothyml[]
+
 //Setup
 
 :allowsuperuser: allow_superuser
@@ -143,7 +151,11 @@ Specify `persisted` to enable <<persistent-queues,persistent queues>> for disk-b
 Default is `memory`.
 
 :pathqueue: path.queue
-:pathqueue-desc: The directory path where the data files will be stored when persistent queues are enabled (`queue.type: persisted`). Default: `path.data/queue`. 
+:pathqueue-desc: The directory path where the data files will be stored when persistent queues are enabled (`queue.type: persisted`). Default: `path.data/queue`.
+
+// # tag::pathqueue-desc[]
+The directory path where the data files will be stored when persistent queues are enabled (`queue.type: persisted`). Default: `path.data/queue`. 
+// # end::pathqueue-desc[]
 
 :queuepage_capacity: queue.page_capacity
 :queuepage_capacity-desc: The queue data consists of append-only data files separated into "pages. +
@@ -151,10 +163,26 @@ This option sets the maximum size of the page data files in bytes (`queue.type: 
 The default size of 64mb is a good value for most users, and changing this value is unlikely to have performance benefits. +
 If you change the page capacity of an existing queue, the new size applies only to the new page. Default is `64mb`.
 
+// # tag::queuepage_capacity-desc[]
+The queue data consists of append-only data files separated into "pages.
+This option sets the maximum size of the page data files in bytes (`queue.type: persisted`). 
+The default size of 64mb is a good value for most users, and changing this value is unlikely to have performance benefits.
+If you change the page capacity of an existing queue, the new size applies only to the new page. Default is `64mb`.
+// # end::queuepage_capacity-desc[]
+
 :queuedrain: queue.drain
 :queuedrain-desc: When set to `true`, Logstash waits until the persistent queue is drained before shutting down. +
 The amount of time it takes to drain the queue depends on the number of events that have accumulated in the queue. +
 Tip: Avoid using this setting unless the queue, even when full, is relatively small and can be drained quickly. Default is `false`.
+
+// # tag::queuedrain-desc[]
+When set to `true`, Logstash waits until the persistent queue is drained before shutting down.
+The amount of time it takes to drain the queue depends on the number of events that have accumulated in the queue.
+
+TIP: Avoid using this setting unless the queue, even when full, is relatively small and can be drained quickly. Default is `false`.
+
+// # end::queuedrain-desc[]
+
 
 :queuemaxevents: queue.max_events
 :queuemaxevents-desc: The maximum number of events not yet read by the pipeline worker (`queue.type: persisted`). The default is `0` (unlimited). +

--- a/docs/static/settings/pq-settings.asciidoc
+++ b/docs/static/settings/pq-settings.asciidoc
@@ -2,11 +2,26 @@
  
 NOTE: These settings apply only if `queue.type: persisted`.
  
-{pathqueue}:: {pathqueue-desc} {lsyml}
+{pathqueue}::
++
+--
+include::{log-repo-dir}/include/attributes-ls.asciidoc[tag=pathqueue-desc]
+include::{log-repo-dir}/include/attributes-ls.asciidoc[tag=lsyml]
+--
 
-{queuepage_capacity}:: {queuepage_capacity-desc} {bothyml}
+{queuepage_capacity}::
++
+--
+include::{log-repo-dir}/include/attributes-ls.asciidoc[tag=queuepage_capacity-desc]
+include::{log-repo-dir}/include/attributes-ls.asciidoc[tag=bothyml]
+--
 
-{queuedrain}:: {queuedrain-desc} {lsyml}
+{queuedrain}::
++
+--
+include::{log-repo-dir}/include/attributes-ls.asciidoc[tag=queuedrain-desc]
+include::{log-repo-dir}/include/attributes-ls.asciidoc[tag=lsyml]
+--
 
 {queuemaxevents}:: {queuemaxevents-desc} {bothyml}
 


### PR DESCRIPTION
This PR posits a way to address the formatting issues in https://github.com/elastic/logstash/pull/14210 by using [tagged regions](https://docs.asciidoctor.org/asciidoc/latest/directives/include-tagged-regions/#tagging-regions) for the descriptions

For example, the changes are visible for the first three PQ settings:

![image](https://user-images.githubusercontent.com/26471269/180879687-fa4c0a7b-5a1c-4bf6-90e7-03d900706945.png)
